### PR TITLE
One template file per job

### DIFF
--- a/examples/1_Excel_import_job.py
+++ b/examples/1_Excel_import_job.py
@@ -46,9 +46,10 @@ client = Connection(server_url).with_credentials("user_name", "password").connec
 # date, if the import should be deferred until that date and time.
 #
 # Different job types require different input files. For example, an Excel import can use a
-# 'template' and one or more 'data' files, or a single 'combined' file. Any additional files
-# to be imported as file attributes should be specified as 'attachment' files. These can be provided
-# as relative or absolute paths or as `pathlib.Path` objects.
+# 'template' and one or more separate 'data' files, or 'combined' files which include both the data
+# and the template. Any additional files to be imported as file or picture attributes should be
+# specified as 'attachment' files. These can be provided as relative or absolute paths or as
+# `pathlib.Path` objects.
 
 # +
 from ansys.grantami.jobqueue import ExcelImportJobRequest
@@ -57,7 +58,7 @@ separate_excel_import_request = ExcelImportJobRequest(
     name="Excel Import (separate template and data files)",
     description="An example excel import job",
     data_files=["data_file_1.xlsx", "data_file_2.xlsx"],
-    template_files=["import_template.xlsx"],
+    template_file="import_template.xlsx",
 )
 separate_excel_import_request
 # -

--- a/examples/2_Text_import_job.py
+++ b/examples/2_Text_import_job.py
@@ -59,7 +59,7 @@ text_import_request = TextImportJobRequest(
     name="Text Import",
     description="An example text import job",
     data_files=["./text_import_data.txt", "./text_import_data.RLT"],
-    template_files=[pathlib.Path("./text_import_template.xml")],
+    template_file=pathlib.Path("./text_import_template.xml"),
 )
 
 text_import_request

--- a/src/ansys/grantami/jobqueue/_models.py
+++ b/src/ansys/grantami/jobqueue/_models.py
@@ -340,8 +340,8 @@ class ExcelImportJobRequest(ImportJobRequest):
         The earliest date and time the job should be executed.
     data_files
         Excel files containing data to be imported.
-    template_files
-        Excel template files.
+    template_file
+        Excel template file.
     combined_files
         Excel files containing data and template information.
     attachment_files
@@ -354,7 +354,7 @@ class ExcelImportJobRequest(ImportJobRequest):
         description: str,
         scheduled_execution_date: Optional[datetime.datetime] = None,
         data_files: Optional[List[Union[str, pathlib.Path]]] = None,
-        template_files: Optional[List[Union[str, pathlib.Path]]] = None,
+        template_file: Optional[Union[str, pathlib.Path]] = None,
         combined_files: Optional[List[Union[str, pathlib.Path]]] = None,
         attachment_files: Optional[List[Union[str, pathlib.Path]]] = None,
     ):
@@ -362,7 +362,7 @@ class ExcelImportJobRequest(ImportJobRequest):
         self._process_files(
             {
                 _FileType.Data: data_files,
-                _FileType.Template: template_files,
+                _FileType.Template: [template_file] if template_file else None,
                 _FileType.Combined: combined_files,
                 _FileType.Attachment: attachment_files,
             }
@@ -392,7 +392,7 @@ class ExcelImportJobRequest(ImportJobRequest):
                 )
         elif not (_FileType.Data in self._file_types and _FileType.Template in self._file_types):
             raise ValueError(
-                "Excel import jobs must contain either a 'Combined' file or 'Data' files and a 'Template' file."
+                "Excel import jobs must contain either a 'Combined' file or both a 'Template' file and 'Data' files."
             )
 
     @property
@@ -414,7 +414,7 @@ class TextImportJobRequest(ImportJobRequest):
         The earliest date and time the job should be executed.
     data_files
         Text files containing data to be imported.
-    template_files
+    template_file
         Text importer template file.
     attachment_files
         Any other files referenced in the data files.
@@ -426,14 +426,14 @@ class TextImportJobRequest(ImportJobRequest):
         description: str,
         scheduled_execution_date: Optional[datetime.datetime] = None,
         data_files: Optional[List[Union[str, pathlib.Path]]] = None,
-        template_files: Optional[List[Union[str, pathlib.Path]]] = None,
+        template_file: Optional[Union[str, pathlib.Path]] = None,
         attachment_files: Optional[List[Union[str, pathlib.Path]]] = None,
     ):
         super().__init__(name, description, scheduled_execution_date)
         self._process_files(
             {
                 _FileType.Data: data_files,
-                _FileType.Template: template_files,
+                _FileType.Template: [template_file] if template_file else None,
                 _FileType.Attachment: attachment_files,
             }
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -51,7 +51,7 @@ def completed_text_import_job(empty_job_queue_api_client: JobQueueApiClient) -> 
         name="TextImportTest",
         description="Import test with text",
         data_files=[TEXT_IMPORT_DATA_FILE],
-        template_files=[TEXT_IMPORT_TEMPLATE_FILE],
+        template_file=TEXT_IMPORT_TEMPLATE_FILE,
     )
     job = empty_job_queue_api_client.create_job_and_wait(job_req)
     check_success(job)
@@ -116,7 +116,7 @@ class TestExcelImportJob:
         job_req = ExcelImportJobRequest(
             name="ExcelImportTest separate files",
             description="Import test 1",
-            template_files=[EXCEL_IMPORT_TEMPLATE_FILE],
+            template_file=EXCEL_IMPORT_TEMPLATE_FILE,
             data_files=[EXCEL_IMPORT_DATA_FILE],
         )
 
@@ -132,7 +132,7 @@ class TestExcelImportJob:
         job_req = ExcelImportJobRequest(
             name="ExcelImportTest separate files with attachment",
             description="Import test 1",
-            template_files=[EXCEL_IMPORT_TEMPLATE_FILE],
+            template_file=EXCEL_IMPORT_TEMPLATE_FILE,
             data_files=[EXCEL_IMPORT_DATA_FILE_WITH_ATTACHMENT],
             attachment_files=[ATTACHMENT],
         )

--- a/tests/test_job_requests.py
+++ b/tests/test_job_requests.py
@@ -13,9 +13,7 @@ from common import (
 EXCEL_TOO_MANY_FILES_ERROR_MESSAGE = (
     "Cannot create Excel import job with both combined and template/data files specified"
 )
-EXCEL_MISSING_FILES_ERROR_MESSAGE = (
-    "Excel import jobs must contain either a 'Combined' file or 'Data' files and a 'Template' file."
-)
+EXCEL_MISSING_FILES_ERROR_MESSAGE = "Excel import jobs must contain either a 'Combined' file or both a 'Template' file and 'Data' files."
 
 
 @pytest.mark.parametrize(
@@ -24,13 +22,13 @@ EXCEL_MISSING_FILES_ERROR_MESSAGE = (
         (
             [EXCEL_IMPORT_COMBINED_FILE],
             [EXCEL_IMPORT_DATA_FILE],
-            [EXCEL_IMPORT_TEMPLATE_FILE],
+            EXCEL_IMPORT_TEMPLATE_FILE,
             EXCEL_TOO_MANY_FILES_ERROR_MESSAGE,
         ),
         (
             [EXCEL_IMPORT_COMBINED_FILE],
             None,
-            [EXCEL_IMPORT_TEMPLATE_FILE],
+            EXCEL_IMPORT_TEMPLATE_FILE,
             EXCEL_TOO_MANY_FILES_ERROR_MESSAGE,
         ),
         (
@@ -54,7 +52,7 @@ EXCEL_MISSING_FILES_ERROR_MESSAGE = (
         (
             None,
             None,
-            [EXCEL_IMPORT_TEMPLATE_FILE],
+            EXCEL_IMPORT_TEMPLATE_FILE,
             EXCEL_MISSING_FILES_ERROR_MESSAGE,
         ),
     ],
@@ -66,7 +64,7 @@ def test_excel_invalid_files_raise_exception(combined, data, template, attachmen
             name="ExcelImportTest",
             description="Import test 1",
             data_files=data,
-            template_files=template,
+            template_file=template,
             combined_files=combined,
             attachment_files=attachment,
         )
@@ -77,7 +75,7 @@ def test_excel_invalid_files_raise_exception(combined, data, template, attachmen
     [
         (None, None),
         ([TEXT_IMPORT_DATA_FILE], None),
-        (None, [TEXT_IMPORT_TEMPLATE_FILE]),
+        (None, TEXT_IMPORT_TEMPLATE_FILE),
     ],
 )
 @pytest.mark.parametrize("attachment", [[ATTACHMENT], None])
@@ -90,6 +88,6 @@ def test_text_invalid_files_raise_exception(data, template, attachment):
             name="ExcelImportTest",
             description="Import test 1",
             data_files=data,
-            template_files=template,
+            template_file=template,
             attachment_files=attachment,
         )


### PR DESCRIPTION
Closes #31 

All jobs only support a single template file, in contrast to data, combined, and attachment files which can be any number. This PR applies that restriction client-side, instead of relying on a server-side failure.