### PR TITLE
Add print statements to example outputs

### DIFF
--- a/examples/2_Text_import_job.py
+++ b/examples/2_Text_import_job.py
@@ -119,5 +119,5 @@ summary_file_name = next(
 )
 output_path = f"./{summary_file_name}"
 text_import_job.download_file(summary_file_name, output_path)
-f"{summary_file_name} saved to disk"
+print(f"{summary_file_name} saved to disk")
 # -

--- a/examples/3_Excel_export_job.py
+++ b/examples/3_Excel_export_job.py
@@ -129,10 +129,10 @@ print(f"{log_file_string[:500]}...")
 output_file_name = next(name for name in completed_job.output_file_names if name.endswith("xlsx"))
 output_path = f"./{output_file_name}"
 completed_job.download_file(output_file_name, output_path)
-f"{output_file_name} saved to disk"
+print(f"{output_file_name} saved to disk")
 
 summary_file_name = next(name for name in completed_job.output_file_names if name == "summary.json")
 output_path = f"./{summary_file_name}"
 completed_job.download_file(summary_file_name, output_path)
-f"{summary_file_name} saved to disk"
+print(f"{summary_file_name} saved to disk")
 # -


### PR DESCRIPTION
Add missing print statements to ensure multiple example outputs are both displayed