### PR TITLE
Fix CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
    :target: https://codecov.io/gh/ansys/grantami-jobqueue
    :alt: Codecov
 
-.. |GH-CI| image:: https://github.com/pyansys/grantami-jobqueue/actions/workflows/ci_cd.yml/badge.svg
+.. |GH-CI| image:: https://github.com/ansys/grantami-jobqueue/actions/workflows/ci_cd.yml/badge.svg
    :target: https://github.com/ansys/grantami-jobqueue/actions/workflows/ci_cd.yml
    :alt: GH-CI
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -89,7 +89,7 @@ autodoc_member_order = "bysource"
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "openapi-common": ("https://openapi.docs.pyansys.com", None),
+    "openapi-common": ("https://openapi.docs.pyansys.com/version/stable", None),
     "requests": ("https://requests.readthedocs.io/en/latest/", None),
     # kept here as an example
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),


### PR DESCRIPTION
Fix link for CI badge
Fix docs build: recent changes to the openapi-common docs deployment changes where the object inventory is located.