### PR TITLE
Skip turning off test VM if there are active workflow runs

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -167,7 +167,7 @@ jobs:
     name: "Stop Azure VM"
     runs-on: ubuntu-latest
     needs: check-workflow-runs
-    if: ${{ always() && !(inputs.skip-vm-management)}}
+    if: always() && !cancelled() && !(inputs.skip-vm-management) && needs.check-workflow-runs.outputs.active-runs != 'true'
     steps:
       - uses: azure/CLI@v2
         with:


### PR DESCRIPTION
Actually skip the VM management step if there are active runs
