### PR TITLE
Only run labeler workflow on pull requests

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
 
     - name: Label based on changed files and branch names


### PR DESCRIPTION
## Include link to relevant issue
Closes #82 

## Describe your changes
Previously, if the labels.yml file was updated and merged to main, the entire workflow would run. Now, only the label-syncer job will run. The others will be filtered out by conditionals or dependencies.