### PR TITLE
Implement changelog actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -128,10 +128,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           doc-artifact-name: documentation-html
 
+  update-changelog:
+    name: "Update CHANGELOG for new tag"
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: ansys/actions/doc-deploy-changelog@v6
+        with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    needs: [build-library, server-checks]
+    needs: [build-library, server-checks, update-changelog]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
       - uses: ansys/actions/release-pypi-public@v6

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,10 @@
 name: Labeler
 on:
   pull_request:
+    # opened, reopened, and synchronize are default for pull_request
+    # edited - when PR title or body is changed
+    # labeled - when labels are added to PR
+    types: [opened, reopened, synchronize, edited, labeled]
   push:
     branches: [ main ]
     paths:
@@ -51,3 +55,16 @@ jobs:
           - [documentation](https://github.com/ansys/grantami-jobqueue/pulls?q=label%3Adocumentation+)
           - [enhancement](https://github.com/ansys/grantami-jobqueue/pulls?q=label%3Aenhancement+)
           - [maintenance](https://github.com/ansys/grantami-jobqueue/pulls?q=label%3Amaintenance+)
+
+  changelog-fragment:
+      name: "Create changelog fragment"
+      needs: [labeler]
+      permissions:
+        contents: write
+        pull-requests: write
+      runs-on: ubuntu-latest
+      if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+      steps:
+      - uses: ansys/actions/doc-changelog@v6
+        with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Changelog
+
+This project uses [towncrier](https://towncrier.readthedocs.io/) and the
+changes for the upcoming release can be found in
+<https://github.com/ansys/grantami-jobqueue/tree/main/doc/changelog.d/>.
+
+<!-- towncrier release notes start -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,38 @@ exclude = [  # don't report on objects that match any of these regexes
     '\.__new__$',
     '\.__init__$',
 ]
+
+[tool.towncrier]
+package = "ansys.grantami.jobqueue"
+directory = "doc/changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+template = "doc/changelog.d/changelog_template.jinja"
+title_format = "## [{version}](https://github.com/ansys/grantami-jobqueue/releases/tag/v{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/ansys/grantami-jobqueue/pull/{issue})"
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "miscellaneous"
+name = "Miscellaneous"
+showcontent = true


### PR DESCRIPTION
## Include link to relevant issue
Closes #88 

## Describe your changes
Implement doc-changelog and doc-deploy-changelog as described in https://actions.docs.ansys.com/version/stable/migrations/docs-deploy-changelog-setup.html. The only variation is to skip generating the changelog fragment for dependabot PRs.