### PR TITLE
Add link to PyGranta version compatibility documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,10 @@ To install a release compatible with a specific version of Granta MI, install th
 
     pip install pygranta==2024.2.0
 
+To see which individual PyGranta package versions are installed with each version of the PyGranta metapackage, consult
+the `Package versions <https://grantami.docs.pyansys.com/version/dev/package_versions.html>`_ section of the PyGranta
+documentation.
+
 Alternatively, to install the latest development version from the `PyGranta JobQueue repository <https://github.com/ansys/grantami-jobqueue>`_,
 run this command:
 

--- a/doc/changelog.d/136.documentation.md
+++ b/doc/changelog.d/136.documentation.md
@@ -1,0 +1,1 @@
+Add link to PyGranta version compatibility documentation


### PR DESCRIPTION
Add a link to the new page that lists dependencies and their versions for each MI version.