### PR TITLE
Fix VM management conditions

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -170,12 +170,13 @@ jobs:
     name: Check if there are active workflow runs
     needs: doc-build
     uses: ansys/pygranta/.github/workflows/check-concurrent-workflows.yml@main
+    if: ${{ !cancelled() }}
 
   stop-vm:
     name: "Stop Azure VM"
     runs-on: ubuntu-latest
     needs: check-workflow-runs
-    if: always() && !cancelled() && !(inputs.skip-vm-management) && needs.check-workflow-runs.outputs.active-runs != 'true'
+    if: ${{ !cancelled() && !(inputs.skip-vm-management) && needs.check-workflow-runs.outputs.active-runs != 'true' }}
     steps:
       - uses: azure/CLI@v2
         with:


### PR DESCRIPTION
When integration tests failed, the job to check whether there are other active workflow runs was skipped and the VM was always turned off.
Adds a condition on the check_workflow_runs job to always run, unless the whole workflow has been cancelled, in which case the VM shutdown is also skipped.