### PR TITLE
Add release environment in CI and prevent release without successful changelog step

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -167,8 +167,9 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    needs: [build-library, server-checks]
+    needs: [build-library, server-checks, update-changelog]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    environment: release
     permissions:
       id-token: write
       contents: write

--- a/doc/changelog.d/143.maintenance.md
+++ b/doc/changelog.d/143.maintenance.md
@@ -1,0 +1,1 @@
+Add release environment in CI and prevent release without succesful changelog step

--- a/doc/changelog.d/143.maintenance.md
+++ b/doc/changelog.d/143.maintenance.md
@@ -1,1 +1,1 @@
-Add release environment in CI and prevent release without succesful changelog step
+Add release environment in CI and prevent release without successful changelog step


### PR DESCRIPTION
## Include link to relevant issue
Closes #142 

## Describe your changes
Adds the release environment
Adds a dependency on the changelog job in the release job

## Checklist before requesting a review
- [ ] I have reviewed my own code.
- [ ] I have added unit and/or integration tests where appropriate.
- [ ] I have documented the new functionality
- [ ] I have annotated the documentation with relevant `versionadded` directives
- [ ] I have added an entry to the CHANGELOG file
