### PR TITLE
Use typeguard to check types at runtime

### DIFF
--- a/doc/changelog.d/160.added.md
+++ b/doc/changelog.d/160.added.md
@@ -1,0 +1,1 @@
+Use typeguard to check types at runtime

--- a/poetry.lock
+++ b/poetry.lock
@@ -3061,6 +3061,24 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
+name = "typeguard"
+version = "4.4.1"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "typeguard-4.4.1-py3-none-any.whl", hash = "sha256:9324ec07a27ec67fc54a9c063020ca4c0ae6abad5e9f0f9804ca59aee68c6e21"},
+    {file = "typeguard-4.4.1.tar.gz", hash = "sha256:0d22a89d00b453b47c49875f42b6601b961757541a2e1e0ef517b6e24213c21b"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.10.0"
+
+[package.extras]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.3.0)"]
+test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -3152,4 +3170,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "eb3c7989aed9f9ebd32fe7451a03d115e0bd5983abc57147538faa2d7e7bcca8"
+content-hash = "6098f169ddd1f4fafe8660999753cbdc0e3a83b9e51ac6b42fff565f72fb8edf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ ansys-openapi-common = "^2.0.0"
 ansys-grantami-serverapi-openapi = "^4.0.0"
 
 # Optional documentation dependencies
+typeguard = "^4.4.1"
 [tool.poetry.group.doc]
 optional = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,8 @@ python = ">=3.10,<4.0"
 ansys-openapi-common = "^2.0.0"
 # Ensure PIP_INDEX_URL is not set in CI when reverting to a public version of the package.
 ansys-grantami-serverapi-openapi = "^4.0.0"
-
-# Optional documentation dependencies
 typeguard = "^4.4.1"
+
 [tool.poetry.group.doc]
 optional = true
 

--- a/src/ansys/grantami/jobqueue/_models.py
+++ b/src/ansys/grantami/jobqueue/_models.py
@@ -30,10 +30,9 @@ import pathlib
 from typing import Any, Dict, List, Optional, Type, Union
 import warnings
 
-from typeguard import typechecked
-
 from ansys.grantami.serverapi_openapi import api, models
 from ansys.openapi.common import UndefinedObjectWarning, Unset
+from typeguard import typechecked
 
 
 class _DocumentedEnum(Enum):

--- a/src/ansys/grantami/jobqueue/_models.py
+++ b/src/ansys/grantami/jobqueue/_models.py
@@ -30,6 +30,8 @@ import pathlib
 from typing import Any, Dict, List, Optional, Type, Union
 import warnings
 
+from typeguard import typechecked
+
 from ansys.grantami.serverapi_openapi import api, models
 from ansys.openapi.common import UndefinedObjectWarning, Unset
 
@@ -169,6 +171,7 @@ class JobFile:
     >>> attachment_file = JobFile(pathlib.Path(r"C:\test_results\pictures\sample_001\panel_front.png"), "./assets/panel_front.png")
     """
 
+    @typechecked()
     def __init__(self, path: Union[str, pathlib.Path], virtual_path: Union[str, pathlib.Path]):
         self._path: pathlib.Path = pathlib.Path(path)
         virtual_path = pathlib.Path(virtual_path)
@@ -665,6 +668,7 @@ class ExcelExportJobRequest(JobRequest):
     <ExcelExportJobRequest: name: "Excel export job (future execution)">
     """
 
+    @typechecked()
     def __init__(
         self,
         name: str,
@@ -816,6 +820,7 @@ class ExcelImportJobRequest(ImportJobRequest):
     <ExcelImportJobRequest: name: "Excel import job (future execution)">
     """
 
+    @typechecked()
     def __init__(
         self,
         name: str,
@@ -926,6 +931,7 @@ class TextImportJobRequest(ImportJobRequest):
     <TextImportJobRequest: name: "Text import job (future execution)">
     """
 
+    @typechecked()
     def __init__(
         self,
         name: str,

--- a/tests/test_job_requests.py
+++ b/tests/test_job_requests.py
@@ -237,7 +237,10 @@ def test_virtual_path_validation(virtual_path, expectation):
 
 class TestInvalidArgumentTypes:
     def test_data_file(self):
-        with pytest.raises(TypeCheckError, match='argument "data_files" (.*) did not match any element in the union'):
+        with pytest.raises(
+            TypeCheckError,
+            match='argument "data_files" (.*) did not match any element in the union',
+        ):
             ExcelImportJobRequest(
                 name="Test name",
                 description=None,
@@ -246,11 +249,12 @@ class TestInvalidArgumentTypes:
 
     def test_date(self):
         with pytest.raises(
-            TypeCheckError, match='argument "scheduled_execution_date" (.*) did not match any element in the union'
+            TypeCheckError,
+            match='argument "scheduled_execution_date" (.*) did not match any element in the union',
         ):
             ExcelImportJobRequest(
                 name="Test name",
                 description=None,
                 data_files=[Path("file.data")],
-                scheduled_execution_date="2024-11-15T20:50:20+00:00"
+                scheduled_execution_date="2024-11-15T20:50:20+00:00",
             )

--- a/tests/test_job_requests.py
+++ b/tests/test_job_requests.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import sys
 
 import pytest
+from typeguard import TypeCheckError
 
 from ansys.grantami.jobqueue import ExcelImportJobRequest, JobFile, TextImportJobRequest
 from common import (
@@ -232,3 +233,24 @@ path_error = pytest.raises(
 def test_virtual_path_validation(virtual_path, expectation):
     with expectation:
         JobFile._validate_virtual_path(virtual_path)
+
+
+class TestInvalidArgumentTypes:
+    def test_data_file(self):
+        with pytest.raises(TypeCheckError, match='argument "data_files" (.*) did not match any element in the union'):
+            ExcelImportJobRequest(
+                name="Test name",
+                description=None,
+                data_files=Path("file.data"),
+            )
+
+    def test_date(self):
+        with pytest.raises(
+            TypeCheckError, match='argument "scheduled_execution_date" (.*) did not match any element in the union'
+        ):
+            ExcelImportJobRequest(
+                name="Test name",
+                description=None,
+                data_files=[Path("file.data")],
+                scheduled_execution_date="2024-11-15T20:50:20+00:00"
+            )


### PR DESCRIPTION
Closes #155 
Closes #159 

Use typeguard to perform run-time type-checking of public class constructors. As reported in the associated tickets, if the correct types are not used then the error messages aren't very clear. typeguard helps here.

Downsides of this approach:

* It doesn't feel very Pythonic. We're using type hints, and any decent IDE or mypy will alert you to your mistake before you run anything.
* Potential performance impacts, but they're not likely to be significant compared to the actual async import type. Also, typeguard will disable these checks if you run Python in 'production mode'.
* It's inconsistent. We're not going to add it anywhere, so why just here?
