### PR TITLE
Prepare for v1.1.0 release

### DIFF
--- a/doc/changelog.d/167.maintenance.md
+++ b/doc/changelog.d/167.maintenance.md
@@ -1,0 +1,1 @@
+Prepare for v1.1.0 release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-grantami-jobqueue"
-version = "1.1.0rc0"
+version = "1.1.0"
 description = "A python wrapper for the Granta MI Job Queue API"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
@@ -14,7 +14,7 @@ readme = "README.rst"
 repository = "https://github.com/ansys/grantami-jobqueue"
 documentation = "https://jobqueue.grantami.docs.pyansys.com"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Prepare v1.1.0 release

I have previously cherry-picked the following releases onto release/1.1:

* ea4e931bc3f7f350c125fd2041284bdec3397d95
* 1d3fce6e42033cc7f7d6256b74864ad42a9496ce
* fa273d05e22baa6e372629e0ae8948add9200d66
* 6a4e232babb5e8f8c72e16976b639c3e71582681

Also cherry-picked d40125641f8f7e9e5874548084e50891ec71cef7 after this PR was created.