### PR TITLE
Fix version number on main branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-grantami-jobqueue"
-version = "1.1.dev0"
+version = "1.2.0dev0"
 description = "A python wrapper for the Granta MI Job Queue API"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Update version number on main to 1.2.0dev0.

Somehow we'd lost the patch version in the version number, so I've added that back in as well.