### PR TITLE
Allow External Code Execution for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ registries:
     password: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
 updates:
   - package-ecosystem: "pip"
+    insecure-external-code-execution: allow
     directory: "/"
     schedule:
       interval: "weekly"

--- a/doc/changelog.d/185.maintenance.md
+++ b/doc/changelog.d/185.maintenance.md
@@ -1,0 +1,1 @@
+Allow External Code Execution for Dependabot


### PR DESCRIPTION
Allow dependabot to execute external code, this is required to run python updates.
