### PR TITLE
Run integration tests on previous releases

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -107,15 +107,15 @@ jobs:
       - name: "Test with tox"
         run: tox -e tests -- -m "not integration"
 
-#      - name: "Upload coverage to Codecov"
-#        uses: codecov/codecov-action@v5
-#        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
-#        env:
-#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-#        with:
-#          files: .cov/xml
-#          flags: unittests
-#          fail_ci_if_error: true
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v5
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: .cov/xml
+          flags: unittests
+          fail_ci_if_error: true
 
   build-library:
     name: "Build library"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -107,15 +107,15 @@ jobs:
       - name: "Test with tox"
         run: tox -e tests -- -m "not integration"
 
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v5
-        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: .cov/xml
-          flags: unittests
-          fail_ci_if_error: true
+#      - name: "Upload coverage to Codecov"
+#        uses: codecov/codecov-action@v5
+#        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+#        env:
+#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#        with:
+#          files: .cov/xml
+#          flags: unittests
+#          fail_ci_if_error: true
 
   build-library:
     name: "Build library"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -107,6 +107,16 @@ jobs:
       - name: "Test with tox"
         run: tox -e tests -- -m "not integration"
 
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v5
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: .cov/xml
+          flags: unittests
+          fail_ci_if_error: true
+
   build-library:
     name: "Build library"
     runs-on: ubuntu-latest

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -78,6 +78,15 @@ jobs:
   start-vm:
     name: "Start Azure VM"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        server:
+          - name: "AZURE_VM_NAME_DEV"
+            url: "TEST_SERVER_DEV_URL"
+          - name: "AZURE_VM_NAME_25R1"
+            url: "TEST_SERVER_25R1_URL"
+          - name: "AZURE_VM_NAME_24R2"
+            url: "TEST_SERVER_24R2_URL"
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v4
@@ -90,7 +99,7 @@ jobs:
           azcliversion: 2.32.0
           inlineScript: |
             az login --service-principal -u ${{ secrets.AZURE_APP_ID }} -p ${{ secrets.AZURE_SECRET }} --tenant ${{ secrets.AZURE_TENANT_ID }}
-            az vm start -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ secrets.AZURE_VM_NAME_DEV }}
+            az vm start -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ secrets[matrix.server.name] }}
 
       - name: "Set up Python ${{ inputs.python-version }}"
         uses: actions/setup-python@v5
@@ -105,7 +114,7 @@ jobs:
           pip freeze
           python .github/scripts/check_server.py
         env:
-          TEST_SL_URL: ${{secrets.TEST_SERVER_URL_NEXT}}
+          TEST_SL_URL: ${{ secrets[matrix.server.url] }}
           TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
 
@@ -174,7 +183,7 @@ jobs:
       - name: "Run Ansys documentation building action"
         uses: ansys/actions/doc-build@v8
         env:
-          TEST_SL_URL: ${{secrets.TEST_SERVER_URL_NEXT}}
+          TEST_SL_URL: ${{secrets.TEST_SERVER_DEV_URL}}
           TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
           BUILD_EXAMPLES: "true"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -59,8 +59,8 @@ on:
 
       PYANSYS_PYPI_PRIVATE_PAT:
         required: true
-      CODECOV_TOKEN:
-        required: true
+#      CODECOV_TOKEN:
+#        required: true
 
   workflow_dispatch:
 
@@ -156,14 +156,14 @@ jobs:
           TEST_READ_USER: ${{secrets.TEST_SERVER_READ_USER}}
           TEST_READ_PASS: ${{secrets.TEST_SERVER_READ_PASS}}
 
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: .cov/xml
-          flags: integration-${{ matrix.os }}-${{ matrix.server }}
-          fail_ci_if_error: true
+#      - name: "Upload coverage to Codecov"
+#        uses: codecov/codecov-action@v5
+#        env:
+#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#        with:
+#          files: .cov/xml
+#          flags: integration-${{ matrix.os }}-${{ matrix.server }}
+#          fail_ci_if_error: true
 
   doc-build:
     name: "Build documentation"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -40,7 +40,11 @@ on:
         required: true
 
       # Test server URLs
-      TEST_SERVER_URL_NEXT:
+      TEST_SERVER_DEV_URL:
+        required: true
+      TEST_SERVER_25R1_URL:
+        required: true
+      TEST_SERVER_24R2_URL:
         required: true
 
       # Test server credentials
@@ -106,13 +110,21 @@ jobs:
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
 
   integration-tests:
-    name: "Integration tests in ${{ matrix.os }}"
+    name: "Integration tests: ${{ matrix.os }}, ${{ matrix.server }}"
     runs-on: ${{ matrix.os }}
     needs: start-vm
     strategy:
-      max-parallel: 1
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os:
+          - "ubuntu-latest"
+          - "windows-latest"
+        server:
+          - "TEST_SERVER_DEV_URL"
+          - "TEST_SERVER_25R1_URL"
+          - "TEST_SERVER_24R2_URL"
+    concurrency:
+      group: ${{ matrix.server }}
+      cancel-in-progress: false
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v4
@@ -129,7 +141,7 @@ jobs:
       - name: "Test with tox (integration tests only)"
         run: tox -e tests
         env:
-          TEST_SL_URL: ${{secrets.TEST_SERVER_URL_NEXT}}
+          TEST_SL_URL: ${{ secrets[matrix.server] }}
           TEST_ADMIN_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_ADMIN_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
           TEST_READ_USER: ${{secrets.TEST_SERVER_READ_USER}}

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -59,8 +59,8 @@ on:
 
       PYANSYS_PYPI_PRIVATE_PAT:
         required: true
-#      CODECOV_TOKEN:
-#        required: true
+      CODECOV_TOKEN:
+        required: true
 
   workflow_dispatch:
 
@@ -156,24 +156,14 @@ jobs:
           TEST_READ_USER: ${{secrets.TEST_SERVER_READ_USER}}
           TEST_READ_PASS: ${{secrets.TEST_SERVER_READ_PASS}}
 
-      - name: "Upload coverage artifacts"
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.os == 'ubuntu-latest' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          name: coverage-html-unittests
-          path: .cov/html
-          retention-days: 7
-
-  #      - name: "Upload coverage to Codecov"
-  #        uses: codecov/codecov-action@v4
-  #        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
-  #        env:
-  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #          with:
-  #          files: .cov/xml
-  #          flags: unittests
-  #          fail_ci_if_error: true
-
+          files: .cov/xml
+          flags: integration-${{ matrix.os }}-${{ matrix.server }}
+          fail_ci_if_error: true
 
   doc-build:
     name: "Build documentation"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -156,14 +156,14 @@ jobs:
           TEST_READ_USER: ${{secrets.TEST_SERVER_READ_USER}}
           TEST_READ_PASS: ${{secrets.TEST_SERVER_READ_PASS}}
 
-#      - name: "Upload coverage to Codecov"
-#        uses: codecov/codecov-action@v5
-#        env:
-#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-#        with:
-#          files: .cov/xml
-#          flags: integration-${{ matrix.os }}-${{ matrix.server }}
-#          fail_ci_if_error: true
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: .cov/xml
+          flags: integration-${{ matrix.os }}-${{ matrix.server }}
+          fail_ci_if_error: true
 
   doc-build:
     name: "Build documentation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,8 @@ filterwarnings = "error"
 markers = [
     """integration(*, mi_versions: None | list[tuple[int, int]] = None): The test requires a real database.
     The optional keyword-only argument \"mi_versions\" represents a MAJOR, MINOR version of Granta MI. The test will \
-    be skipped if run against an incompatible Granta MI version. Note that this package tests functionality in the \
-    RS & Sustainability reports package, which is compatible with multiple Granta MI versions. However, when testing \
-    this package, the same version of the reports package and Granta MI are always used together.
-    Deselect all integration tests with 'pytest -m \"not integration\"'""",
+    be skipped if run against an incompatible Granta MI version. Deselect all integration tests with \
+    'pytest -m \"not integration\"'""",
 ]
 
 [tool.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,12 @@ show_missing = true
 [tool.pytest.ini_options]
 filterwarnings = "error"
 markers = [
-    """integration: test requires a real database (deselect with '-m \"not integration\"')"""
+    """integration(*, mi_versions: None | list[tuple[int, int]] = None): The test requires a real database.
+    The optional keyword-only argument \"mi_versions\" represents a MAJOR, MINOR version of Granta MI. The test will \
+    be skipped if run against an incompatible Granta MI version. Note that this package tests functionality in the \
+    RS & Sustainability reports package, which is compatible with multiple Granta MI versions. However, when testing \
+    this package, the same version of the reports package and Granta MI are always used together.
+    Deselect all integration tests with 'pytest -m \"not integration\"'""",
 ]
 
 [tool.pydocstyle]

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,7 +23,7 @@
 import datetime
 import pathlib
 import time
-from typing import List, Tuple
+from typing import List, Tuple, cast
 
 from ansys.grantami.serverapi_openapi import api, models
 from ansys.openapi.common import ApiClient
@@ -132,3 +132,11 @@ def search_for_records_by_name(client: ApiClient, name: str) -> List[Tuple[str, 
         database_key=DB_KEY, table_guid=table_guid, body=request
     )
     return [(r.record_history_guid, r.record_guid) for r in response.results]
+
+
+def get_granta_mi_version(client: ApiClient) -> tuple[int, int] | None:
+    schema_api = api.SchemaApi(client)
+    version = schema_api.get_version()
+    parsed_version = [int(v) for v in version.major_minor_version.split(".")]
+    assert len(parsed_version) == 2
+    return cast(tuple[int, int], tuple(parsed_version))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,26 +29,44 @@ import pytest
 from ansys.grantami.jobqueue import Connection, JobQueueApiClient
 from common import FOLDER_NAME, delete_record, generate_now, get_granta_mi_version
 
-sl_url = os.getenv("TEST_SL_URL", "http://localhost/mi_servicelayer")
-admin_username = os.getenv("TEST_ADMIN_USER")
-admin_password = os.getenv("TEST_ADMIN_PASS")
 
-
-def _get_configured_connection():
-    if all([admin_username, admin_password]):
-        return Connection(sl_url).with_credentials(admin_username, admin_password)
-    if not any([admin_username, admin_password]):
-        return Connection(sl_url).with_autologon()
-    raise ValueError("Specify both or neither of username and password.")
+@pytest.fixture(scope="session")
+def sl_url():
+    return os.getenv("TEST_SL_URL", "http://localhost/mi_servicelayer")
 
 
 @pytest.fixture(scope="session")
-def job_queue_api_client():
+def admin_username():
+    return os.getenv("TEST_ADMIN_USER")
+
+
+@pytest.fixture(scope="session")
+def admin_password():
+    return os.getenv("TEST_ADMIN_PASS")
+
+
+@pytest.fixture(scope="session")
+def username_read_permissions():
+    return os.getenv("TEST_READ_USER")
+
+
+@pytest.fixture(scope="session")
+def password_read_permissions():
+    return os.getenv("TEST_READ_PASS")
+
+
+@pytest.fixture(scope="session")
+def job_queue_api_client(sl_url, admin_username, admin_password):
     """
     Fixture providing a real ApiClient to run integration tests against an instance of Granta MI
     Server API.
     """
-    connection = _get_configured_connection()
+    if all([admin_username, admin_password]):
+        connection = Connection(sl_url).with_credentials(admin_username, admin_password)
+    elif not any([admin_username, admin_password]):
+        connection = Connection(sl_url).with_autologon()
+    else:
+        raise ValueError("Specify both or neither of TEST_ADMIN_USER and TEST_ADMIN_PASS.")
     client: JobQueueApiClient = connection.connect()
     clear_job_queue(client)
     delete_record(
@@ -100,7 +118,7 @@ def clear_job_queue(client: JobQueueApiClient):
 
 
 @pytest.fixture(scope="session")
-def mi_version(sl_url, admin_username, admin_password) -> tuple[int, int] | None:
+def mi_version(request) -> tuple[int, int] | None:
     """The version of MI referenced by the test url.
 
     Returns
@@ -115,7 +133,7 @@ def mi_version(sl_url, admin_username, admin_password) -> tuple[int, int] | None
     """
     if os.getenv("CI") and not os.getenv("TEST_SL_URL"):
         return None
-    client = _get_configured_connection().connect()
+    client = request.getfixturevalue("job_queue_api_client")
     return get_granta_mi_version(client)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -264,7 +264,7 @@ class TestExcelImportJob:
         job_req = ExcelImportJobRequest(
             name="Invalid combined file",
             description="Invalid combined file",
-            combined_files=[JobFile(__file__, "test_integration_25_1_24_2.py")],
+            combined_files=[JobFile(__file__, "test_integration.py")],
         )
 
         job = empty_job_queue_api_client.create_job_and_wait(job_req)
@@ -279,7 +279,7 @@ class TestExcelImportJob:
         job_req = ExcelImportJobRequest(
             name="Invalid combined file",
             description="Invalid combined file",
-            combined_files=[JobFile(__file__, "test_integration_25_1_24_2.py")],
+            combined_files=[JobFile(__file__, "test_integration.py")],
         )
 
         job = empty_job_queue_api_client.create_job_and_wait(job_req)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 import datetime
-import json
 import os
 from pathlib import Path
 import shutil
@@ -58,7 +57,7 @@ from common import (
     search_for_records_by_name,
 )
 
-pytestmark = pytest.mark.integration(mi_versions=[(24, 2), (25, 1)])
+pytestmark = pytest.mark.integration(mi_versions=[(25, 2)])
 
 
 @pytest.fixture(scope="function")
@@ -265,7 +264,7 @@ class TestExcelImportJob:
         job_req = ExcelImportJobRequest(
             name="Invalid combined file",
             description="Invalid combined file",
-            combined_files=[JobFile(__file__, "test_integration.py")],
+            combined_files=[JobFile(__file__, "test_integration_25_1_24_2.py")],
         )
 
         job = empty_job_queue_api_client.create_job_and_wait(job_req)
@@ -280,7 +279,7 @@ class TestExcelImportJob:
         job_req = ExcelImportJobRequest(
             name="Invalid combined file",
             description="Invalid combined file",
-            combined_files=[JobFile(__file__, "test_integration.py")],
+            combined_files=[JobFile(__file__, "test_integration_25_1_24_2.py")],
         )
 
         job = empty_job_queue_api_client.create_job_and_wait(job_req)
@@ -477,88 +476,76 @@ class TestFileOutputs:
     def test_excel_import_output_files(self, completed_excel_combined_import_job):
         job = completed_excel_combined_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filename = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
-        )
-        summary = job.get_file_content(summary_filename)
-        parsed_summary = json.loads(summary.decode("utf-8"))
-        assert parsed_summary["NumberOfTasks"] == 1
-        assert parsed_summary["NumberOfErrors"] == 0
+        assert len(job.output_file_names) == 1
+        summary = job.output_information["summary"]
+        assert summary["NumberOfTasks"] == 1
+        assert summary["NumberOfErrors"] == 0
 
     def test_excel_import_download_files_name(self, completed_excel_combined_import_job):
         job = completed_excel_combined_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "ExcelImportTest.log" in file_name
         )
         with tempfile.TemporaryDirectory() as td:
-            output_file = os.path.join(td, "file_name.json")
-            job.download_file(summary_filepath, output_file)
+            output_file = os.path.join(td, "file_name.log")
+            job.download_file(log_filepath, output_file)
             assert os.path.exists(output_file)
 
     def test_excel_import_download_files_path(self, completed_excel_combined_import_job):
         job = completed_excel_combined_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "ExcelImportTest.log" in file_name
         )
-        summary_filename = summary_filepath.split("\\")[-1]
+        log_filename = log_filepath.split("\\")[-1]
         with tempfile.TemporaryDirectory() as td:
-            job.download_file(summary_filepath, td)
-            output_file = os.path.join(td, summary_filename)
+            job.download_file(log_filepath, td)
+            output_file = os.path.join(td, log_filename)
             assert os.path.exists(output_file)
 
     def test_text_import_output_files(self, completed_text_import_job):
         job = completed_text_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filename = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
-        )
-        summary = job.get_file_content(summary_filename)
-        parsed_summary = json.loads(summary.decode("utf-8"))
-        assert parsed_summary["NumberOfTasks"] == 1
-        assert parsed_summary["NumberOfErrors"] == 0
+        assert len(job.output_file_names) == 1
+        summary = job.output_information["summary"]
+        assert summary["NumberOfTasks"] == 1
+        assert summary["NumberOfErrors"] == 0
 
     def test_text_import_download_files_name(self, completed_text_import_job):
         job = completed_text_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "TextImportTest.log" in file_name
         )
         with tempfile.TemporaryDirectory() as td:
-            output_file = os.path.join(td, "file_name.json")
-            job.download_file(summary_filepath, output_file)
+            output_file = os.path.join(td, "file_name.log")
+            job.download_file(log_filepath, output_file)
             assert os.path.exists(output_file)
 
     def test_text_import_download_files_path(self, completed_text_import_job):
         job = completed_text_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "TextImportTest.log" in file_name
         )
-        summary_filename = summary_filepath.split("\\")[-1]
+        log_filename = log_filepath.split("\\")[-1]
         with tempfile.TemporaryDirectory() as td:
-            job.download_file(summary_filepath, td)
-            output_file = os.path.join(td, summary_filename)
+            job.download_file(log_filepath, td)
+            output_file = os.path.join(td, log_filename)
             assert os.path.exists(output_file)
 
     def test_export_output_files(self, completed_excel_export_job):
         job = completed_excel_export_job
 
-        assert len(job.output_file_names) == 3
-        summary_filename = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
-        )
-        summary = job.get_file_content(summary_filename)
-        parsed_summary = json.loads(summary.decode("utf-8"))
-        assert parsed_summary["ExportedRecords"] == 2
-        assert parsed_summary["Errors"] == []
+        assert len(job.output_file_names) == 2
+        summary = job.output_information["summary"]
+        assert summary["ExportedRecords"] == 2
+        assert summary["Errors"] == []
 
 
 class TestSearch:

--- a/tests/test_integration_25_2.py
+++ b/tests/test_integration_25_2.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 import datetime
-import json
 import os
 from pathlib import Path
 import shutil
@@ -58,7 +57,7 @@ from common import (
     search_for_records_by_name,
 )
 
-pytestmark = pytest.mark.integration(mi_versions=[(24, 2), (25, 1)])
+pytestmark = pytest.mark.integration(mi_versions=[(25, 2)])
 
 
 @pytest.fixture(scope="function")
@@ -477,88 +476,76 @@ class TestFileOutputs:
     def test_excel_import_output_files(self, completed_excel_combined_import_job):
         job = completed_excel_combined_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filename = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
-        )
-        summary = job.get_file_content(summary_filename)
-        parsed_summary = json.loads(summary.decode("utf-8"))
-        assert parsed_summary["NumberOfTasks"] == 1
-        assert parsed_summary["NumberOfErrors"] == 0
+        assert len(job.output_file_names) == 1
+        summary = job.output_information["summary"]
+        assert summary["NumberOfTasks"] == 1
+        assert summary["NumberOfErrors"] == 0
 
     def test_excel_import_download_files_name(self, completed_excel_combined_import_job):
         job = completed_excel_combined_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "ExcelImportTest.log" in file_name
         )
         with tempfile.TemporaryDirectory() as td:
-            output_file = os.path.join(td, "file_name.json")
-            job.download_file(summary_filepath, output_file)
+            output_file = os.path.join(td, "file_name.log")
+            job.download_file(log_filepath, output_file)
             assert os.path.exists(output_file)
 
     def test_excel_import_download_files_path(self, completed_excel_combined_import_job):
         job = completed_excel_combined_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "ExcelImportTest.log" in file_name
         )
-        summary_filename = summary_filepath.split("\\")[-1]
+        log_filename = log_filepath.split("\\")[-1]
         with tempfile.TemporaryDirectory() as td:
-            job.download_file(summary_filepath, td)
-            output_file = os.path.join(td, summary_filename)
+            job.download_file(log_filepath, td)
+            output_file = os.path.join(td, log_filename)
             assert os.path.exists(output_file)
 
     def test_text_import_output_files(self, completed_text_import_job):
         job = completed_text_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filename = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
-        )
-        summary = job.get_file_content(summary_filename)
-        parsed_summary = json.loads(summary.decode("utf-8"))
-        assert parsed_summary["NumberOfTasks"] == 1
-        assert parsed_summary["NumberOfErrors"] == 0
+        assert len(job.output_file_names) == 1
+        summary = job.output_information["summary"]
+        assert summary["NumberOfTasks"] == 1
+        assert summary["NumberOfErrors"] == 0
 
     def test_text_import_download_files_name(self, completed_text_import_job):
         job = completed_text_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "TextImportTest.log" in file_name
         )
         with tempfile.TemporaryDirectory() as td:
-            output_file = os.path.join(td, "file_name.json")
-            job.download_file(summary_filepath, output_file)
+            output_file = os.path.join(td, "file_name.log")
+            job.download_file(log_filepath, output_file)
             assert os.path.exists(output_file)
 
     def test_text_import_download_files_path(self, completed_text_import_job):
         job = completed_text_import_job
 
-        assert len(job.output_file_names) == 2
-        summary_filepath = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
+        assert len(job.output_file_names) == 1
+        log_filepath = next(
+            file_name for file_name in job.output_file_names if "TextImportTest.log" in file_name
         )
-        summary_filename = summary_filepath.split("\\")[-1]
+        log_filename = log_filepath.split("\\")[-1]
         with tempfile.TemporaryDirectory() as td:
-            job.download_file(summary_filepath, td)
-            output_file = os.path.join(td, summary_filename)
+            job.download_file(log_filepath, td)
+            output_file = os.path.join(td, log_filename)
             assert os.path.exists(output_file)
 
     def test_export_output_files(self, completed_excel_export_job):
         job = completed_excel_export_job
 
-        assert len(job.output_file_names) == 3
-        summary_filename = next(
-            file_name for file_name in job.output_file_names if "summary.json" in file_name
-        )
-        summary = job.get_file_content(summary_filename)
-        parsed_summary = json.loads(summary.decode("utf-8"))
-        assert parsed_summary["ExportedRecords"] == 2
-        assert parsed_summary["Errors"] == []
+        assert len(job.output_file_names) == 2
+        summary = job.output_information["summary"]
+        assert summary["ExportedRecords"] == 2
+        assert summary["Errors"] == []
 
 
 class TestSearch:

--- a/tox.ini
+++ b/tox.ini
@@ -22,15 +22,25 @@ passenv =
     TEST_ADMIN_PASS
     TEST_READ_USER
     TEST_READ_PASS
-    CI
     POETRY_HTTP_BASIC_PRIVATE_PYPI_USERNAME
     POETRY_HTTP_BASIC_PRIVATE_PYPI_PASSWORD
+    CI
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = --cov=ansys.grantami.jobqueue --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html
 commands =
     poetry install
     poetry run pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+
+[testenv:style]
+description = Checks project code style
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit install
+    poetry install
+    poetry run -- pre-commit run --all-files --show-diff-on-failure
 
 [testenv:doc]
 description = Check if documentation generates properly

--- a/tox.ini
+++ b/tox.ini
@@ -22,25 +22,15 @@ passenv =
     TEST_ADMIN_PASS
     TEST_READ_USER
     TEST_READ_PASS
+    CI
     POETRY_HTTP_BASIC_PRIVATE_PYPI_USERNAME
     POETRY_HTTP_BASIC_PRIVATE_PYPI_PASSWORD
-    CI
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = --cov=ansys.grantami.jobqueue --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html
 commands =
     poetry install
     poetry run pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
-
-[testenv:style]
-description = Checks project code style
-skip_install = true
-deps =
-    pre-commit
-commands =
-    pre-commit install
-    poetry install
-    poetry run -- pre-commit run --all-files --show-diff-on-failure
 
 [testenv:doc]
 description = Check if documentation generates properly

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ passenv =
     TEST_READ_PASS
     POETRY_HTTP_BASIC_PRIVATE_PYPI_USERNAME
     POETRY_HTTP_BASIC_PRIVATE_PYPI_PASSWORD
+    CI
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = --cov=ansys.grantami.jobqueue --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html


### PR DESCRIPTION
Closes #183 

Copy the new mark functionality from grantami-bomanalytics, but use Server API to access the version instead of the XML-based HTTP endpoint.

I did think if it would be possible to package this into a plugin, but I think it would be difficult to handle without a stable Server API with which to talk to MI.