### PR TITLE
Add Granta MI 2024 R1 integration tests

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -46,6 +46,8 @@ on:
         required: true
       TEST_SERVER_24R2_URL:
         required: true
+      TEST_SERVER_24R1_URL:
+        required: true
 
       # Test server credentials
       TEST_SERVER_ADMIN_USER:
@@ -59,8 +61,8 @@ on:
 
       PYANSYS_PYPI_PRIVATE_PAT:
         required: true
-#      CODECOV_TOKEN:
-#        required: true
+      CODECOV_TOKEN:
+        required: true
 
   workflow_dispatch:
 
@@ -87,6 +89,8 @@ jobs:
             url: "TEST_SERVER_25R1_URL"
           - name: "AZURE_VM_NAME_24R2"
             url: "TEST_SERVER_24R2_URL"
+          - name: "AZURE_VM_NAME_24R1"
+            url: "TEST_SERVER_24R1_URL"
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v4
@@ -119,7 +123,7 @@ jobs:
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
 
   integration-tests:
-    name: "Integration tests: ${{ matrix.os }}, ${{ matrix.server }}"
+    name: "Integration tests: ${{ matrix.os }}, ${{ matrix.server.version }}"
     runs-on: ${{ matrix.os }}
     needs: start-vm
     strategy:
@@ -128,11 +132,16 @@ jobs:
           - "ubuntu-latest"
           - "windows-latest"
         server:
-          - "TEST_SERVER_DEV_URL"
-          - "TEST_SERVER_25R1_URL"
-          - "TEST_SERVER_24R2_URL"
+          - url: "TEST_SERVER_DEV_URL"
+            version: "25.2"
+          - url: "TEST_SERVER_25R1_URL"
+            version: "25.1"
+          - url: "TEST_SERVER_24R2_URL"
+            version: "24.2"
+          - url: "TEST_SERVER_24R1_URL"
+            version: "24.1"
     concurrency:
-      group: ${{ matrix.server }}
+      group: ${{ matrix.server.url }}
       cancel-in-progress: false
     steps:
       - name: "Checkout the repository"
@@ -148,9 +157,9 @@ jobs:
           pip install poetry 'tox<4' --disable-pip-version-check
 
       - name: "Test with tox (integration tests only)"
-        run: tox -e tests
+        run: tox -e tests -- -m "integration" --mi-version ${{ matrix.server.version }}
         env:
-          TEST_SL_URL: ${{ secrets[matrix.server] }}
+          TEST_SL_URL: ${{ secrets[matrix.server.url] }}
           TEST_ADMIN_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_ADMIN_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
           TEST_READ_USER: ${{secrets.TEST_SERVER_READ_USER}}
@@ -162,7 +171,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: .cov/xml
-          flags: integration-${{ matrix.os }}-${{ matrix.server }}
+          flags: integration-${{ matrix.os }}-${{ matrix.server.version }}
           fail_ci_if_error: true
 
   doc-build:

--- a/doc/changelog.d/189.maintenance.md
+++ b/doc/changelog.d/189.maintenance.md
@@ -1,0 +1,1 @@
+Add 24.1 tests, manually specify server version

--- a/doc/changelog.d/189.maintenance.md
+++ b/doc/changelog.d/189.maintenance.md
@@ -1,1 +1,1 @@
-Add 24.1 tests, manually specify server version
+Add Granta MI 2024 R1 integration tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ markers = [
     """integration(*, mi_versions: None | list[tuple[int, int]] = None): The test requires a real database.
     The optional keyword-only argument \"mi_versions\" represents a MAJOR, MINOR version of Granta MI. The test will \
     be skipped if run against an incompatible Granta MI version. Deselect all integration tests with \
-    'pytest -m \"not integration\"'""",
+    'pytest -m \"not integration\"'.  Specify MI version with '--mi-version MAJOR.MINOR'.""",
 ]
 
 [tool.pydocstyle]

--- a/tests/test_integration_24_1.py
+++ b/tests/test_integration_24_1.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2024 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from ansys.grantami.jobqueue import Connection
+
+pytestmark = pytest.mark.integration(mi_versions=[(24, 1)])
+
+
+def test_connection(admin_username, admin_password, sl_url):
+    with pytest.raises(
+        ConnectionError,
+        match=r"Cannot find the Server API definition in the Granta MI Service Layer",
+    ):
+        Connection(sl_url).with_credentials(admin_username, admin_password).connect()


### PR DESCRIPTION
Add a connection test for Granta MI 2024 R1.

Copy MI Version code from the RecordLists repo, but with a slight improvement to better handle the case where an MI Version number is not provided. Without this fix, attempting to run integration tests without a specified mi version number raises a TypeError when `None` is parsed.

We should maybe investigate a pytest plugin to handle this. It could be made fairly generic, especially since it now accepts the integration host version as an argument.