### PR TITLE
Improve documentation for Granta MI version support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Dependencies
 .. readme_software_requirements
 
 This version of the ``ansys.grantami.jobqueue`` package requires Granta MI 2024 R2 or newer. Use
-`the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions.html/>`_ to find the
+`the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions>`_ to find the
 version of this package compatible with older Granta MI versions.
 
 The ``ansys.grantami.jobqueue`` package currently supports Python from version 3.10 to version 3.13.

--- a/README.rst
+++ b/README.rst
@@ -44,9 +44,11 @@ Dependencies
 ------------
 .. readme_software_requirements
 
-To use PyGranta JobQueue, you must have access to a Granta MI 2024 R2 deployment.
+This version of the ``ansys.grantami.jobqueue`` package requires Granta MI 2024 R2 or newer. Use
+`the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions.html/>`_ to find the
+version of this package compatible with older Granta MI versions.
 
-The ``ansys.grantami.jobqueue`` package currently supports Python version 3.10 through 3.13.
+The ``ansys.grantami.jobqueue`` package currently supports Python from version 3.10 to version 3.13.
 
 .. readme_software_requirements_end
 

--- a/doc/changelog.d/215.documentation.md
+++ b/doc/changelog.d/215.documentation.md
@@ -1,0 +1,1 @@
+Improve documentation for Granta MI version support


### PR DESCRIPTION
Closes #214 

Refer to the improved PyGranta metapackage documentation for guidance on how to determine package compatibility for unsupported Granta MI versions.

The link points to the version table page, which is updated as part of https://github.com/ansys/pygranta/pull/175
