### PR TITLE
Add integration checks completeness check

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -145,6 +145,15 @@ jobs:
     secrets:
       inherit
 
+  integration-checks-complete:
+    name: "Integration checks complete"
+    runs-on: ubuntu-latest
+    if: always() && ( startsWith( github.event.pull_request.head.ref, 'dependabot/') || needs.server-checks.result == 'success' )
+    needs: server-checks
+    steps:
+      - name: "Integration checks complete"
+        run: echo "Integration checks complete"
+
   doc-deploy-dev:
     name: "Deploy development documentation"
     runs-on: ubuntu-latest

--- a/doc/changelog.d/224.maintenance.md
+++ b/doc/changelog.d/224.maintenance.md
@@ -1,0 +1,1 @@
+Add integration checks completeness check


### PR DESCRIPTION
## Include link to relevant issue
Closes #209

## Describe your changes
Adds a step in CI that can be used as required check to check whether integration checks have successfully run or have been skipped if the author is dependabot.

