### PR TITLE
Move release branch to use 25R2 release VM

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -32,6 +32,8 @@ on:
       # Test server names
       AZURE_VM_NAME_DEV:
         required: true
+      AZURE_VM_NAME_25R2:
+        required: true
       AZURE_VM_NAME_25R1:
         required: true
       AZURE_VM_NAME_24R2:
@@ -41,6 +43,8 @@ on:
 
       # Test server URLs
       TEST_SERVER_DEV_URL:
+        required: true
+      TEST_SERVER_25R2_URL:
         required: true
       TEST_SERVER_25R1_URL:
         required: true
@@ -78,8 +82,8 @@ jobs:
     strategy:
       matrix:
         server:
-          - name: "AZURE_VM_NAME_DEV"
-            url: "TEST_SERVER_DEV_URL"
+          - name: "AZURE_VM_NAME_25R2"
+            url: "TEST_SERVER_25R2_URL"
           - name: "AZURE_VM_NAME_25R1"
             url: "TEST_SERVER_25R1_URL"
           - name: "AZURE_VM_NAME_24R2"
@@ -127,7 +131,7 @@ jobs:
           - "ubuntu-latest"
           - "windows-latest"
         server:
-          - url: "TEST_SERVER_DEV_URL"
+          - url: "TEST_SERVER_25R2_URL"
             version: "25.2"
           - url: "TEST_SERVER_25R1_URL"
             version: "25.1"
@@ -201,6 +205,7 @@ jobs:
       matrix:
         server:
           - "AZURE_VM_NAME_DEV"
+          - "AZURE_VM_NAME_25R2"
           - "AZURE_VM_NAME_25R1"
           - "AZURE_VM_NAME_24R2"
           - "AZURE_VM_NAME_24R1"

--- a/doc/changelog.d/226.maintenance.md
+++ b/doc/changelog.d/226.maintenance.md
@@ -1,0 +1,1 @@
+Move release branch to use 25R2 release VM


### PR DESCRIPTION
Move release branch to use 25R2 release VM.

Add 25R2 to start VM,  tests, and stop VM steps.
Remove dev machine from start VM and tests steps.