### PR TITLE
Fix version number on main branch

### DIFF
--- a/doc/changelog.d/234.maintenance.md
+++ b/doc/changelog.d/234.maintenance.md
@@ -1,0 +1,1 @@
+Fix version number on main branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-grantami-jobqueue"
-version = "1.3.0dev0"
+version = "1.3.0.dev0"
 description = "A python wrapper for the Granta MI Job Queue API"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Python version numbering requires a `.` before a dev version number to ensure it is applied correctly. As currently written, pip may incorrectly resolve the latest version when comparing this version to a future alpha, beta, rc, or final release.