### PR TITLE
Fix documentation server for build

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -181,7 +181,7 @@ jobs:
       - name: "Run Ansys documentation building action"
         uses: ansys/actions/doc-build@5dc39c7838f50142138f7ac518ff3e4dca065d97  # v9.0.12
         env:
-          TEST_SL_URL: ${{secrets.TEST_SERVER_DEV_URL}}
+          TEST_SL_URL: ${{secrets.TEST_SERVER_25R2_URL}}
           TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
           BUILD_EXAMPLES: "true"

--- a/doc/changelog.d/239.fixed.md
+++ b/doc/changelog.d/239.fixed.md
@@ -1,0 +1,1 @@
+Fix documentation server for build


### PR DESCRIPTION
When we removed the dev test server from the release branch, we forgot to change the server used by the documentation build step. I assume that for all previous PR runs against the release branch, the dev machine happened to be already running.

This PR fixes that issue, which caused a failure with the 1.2.0rc0 release.