### PR TITLE
Fix server_check.py call in CI

### DIFF
--- a/.github/scripts/check_server.py
+++ b/.github/scripts/check_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S uv run --script
 #
 # /// script
+# requires-python = ">=3.10"
 # dependencies = ["requests"]
 # ///
 

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: "Check if server is ready"
         run: |
-          uv run --frozen ./.github/scripts/check_server.py
+          uv run ./.github/scripts/check_server.py
         env:
           TEST_SL_URL: ${{ secrets[matrix.server.url] }}   # zizmor: ignore[overprovisioned-secrets,obfuscation] - No support in matrix for variable interpolation
           TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}

--- a/doc/changelog.d/382.maintenance.md
+++ b/doc/changelog.d/382.maintenance.md
@@ -1,0 +1,1 @@
+Fix server_check.py call in CI


### PR DESCRIPTION
The CI step that checks if the server is ready or not is a uv-annotated script. When run with `--frozen`, uv uses a lockfile specific to the script, instead of for the project.

This PR removes `--frozen`, since bumping the lockfile is not currently supported by dependabot. Instead, we'll just grab the latest dependencies on each run. We will sacrifice repeatability here, but this is unlikely to be significant considering it's not part of the actual release, it's just a utility like the precise version of git.

Also add an explicit Python version, otherwise uv will default to 3.14.

This seems to be the only repo affected by this, the others don't use `--frozen`.