### PR TITLE
Convert class-scoped fixtures to class methods

### DIFF
--- a/doc/changelog.d/415.fixed.md
+++ b/doc/changelog.d/415.fixed.md
@@ -1,0 +1,1 @@
+Convert class-scoped fixtures to class methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,13 +151,13 @@ title_format = "`{version} <https://github.com/ansys/grantami-jobqueue/releases/
 issue_format = "`#{issue} <https://github.com/ansys/grantami-jobqueue/pull/{issue}>`_"
 
 [[tool.towncrier.type]]
-directory = "added"
-name = "Added"
+directory = "breaking"
+name = "Breaking"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "changed"
-name = "Changed"
+directory = "added"
+name = "Added"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -166,18 +166,13 @@ name = "Fixed"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "dependencies"
-name = "Dependencies"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "miscellaneous"
-name = "Miscellaneous"
-showcontent = true
-
-[[tool.towncrier.type]]
 directory = "documentation"
 name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -186,8 +181,18 @@ name = "Maintenance"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "miscellaneous"
+name = "Miscellaneous"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "test"
 name = "Test"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
 showcontent = true
 
 [tool.bandit]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -332,30 +332,35 @@ class TestPaths:
     attachment_filename = "picture.bmp"
 
     @pytest.fixture(scope="class")
-    def directory(self, tmp_path_factory):
+    @classmethod
+    def directory(cls, tmp_path_factory):
         yield tmp_path_factory.mktemp("directory")
 
     @pytest.fixture(scope="class")
-    def template_path_absolute(self, directory):
-        template_path = Path(directory, self.template_filename)
+    @classmethod
+    def template_path_absolute(cls, directory):
+        template_path = Path(directory, cls.template_filename)
         shutil.copy(TEXT_IMPORT_TEMPLATE_FILE, template_path)
         yield template_path.absolute()
 
     @pytest.fixture(scope="class")
-    def datafile_path_absolute(self, directory):
-        datafile_path = Path(directory, self.datafile_filename)
+    @classmethod
+    def datafile_path_absolute(cls, directory):
+        datafile_path = Path(directory, cls.datafile_filename)
         shutil.copy(TEXT_IMPORT_DATA_FILE, datafile_path)
         yield datafile_path.absolute()
 
     @pytest.fixture(scope="class")
-    def attachment_path_absolute(self, directory):
-        attachment_path = Path(directory, self.attachment_filename)
+    @classmethod
+    def attachment_path_absolute(cls, directory):
+        attachment_path = Path(directory, cls.attachment_filename)
         shutil.copy(ATTACHMENT, attachment_path)
         yield attachment_path.absolute()
 
     @pytest.fixture(scope="class")
+    @classmethod
     def populated_directory(
-        self, directory, template_path_absolute, datafile_path_absolute, attachment_path_absolute
+        cls, directory, template_path_absolute, datafile_path_absolute, attachment_path_absolute
     ):
         yield directory
 

--- a/tests/test_integration_25_1_24_2.py
+++ b/tests/test_integration_25_1_24_2.py
@@ -333,30 +333,35 @@ class TestPaths:
     attachment_filename = "picture.bmp"
 
     @pytest.fixture(scope="class")
-    def directory(self, tmp_path_factory):
+    @classmethod
+    def directory(cls, tmp_path_factory):
         yield tmp_path_factory.mktemp("directory")
 
     @pytest.fixture(scope="class")
-    def template_path_absolute(self, directory):
-        template_path = Path(directory, self.template_filename)
+    @classmethod
+    def template_path_absolute(cls, directory):
+        template_path = Path(directory, cls.template_filename)
         shutil.copy(TEXT_IMPORT_TEMPLATE_FILE, template_path)
         yield template_path.absolute()
 
     @pytest.fixture(scope="class")
-    def datafile_path_absolute(self, directory):
-        datafile_path = Path(directory, self.datafile_filename)
+    @classmethod
+    def datafile_path_absolute(cls, directory):
+        datafile_path = Path(directory, cls.datafile_filename)
         shutil.copy(TEXT_IMPORT_DATA_FILE, datafile_path)
         yield datafile_path.absolute()
 
     @pytest.fixture(scope="class")
-    def attachment_path_absolute(self, directory):
-        attachment_path = Path(directory, self.attachment_filename)
+    @classmethod
+    def attachment_path_absolute(cls, directory):
+        attachment_path = Path(directory, cls.attachment_filename)
         shutil.copy(ATTACHMENT, attachment_path)
         yield attachment_path.absolute()
 
     @pytest.fixture(scope="class")
+    @classmethod
     def populated_directory(
-        self, directory, template_path_absolute, datafile_path_absolute, attachment_path_absolute
+        cls, directory, template_path_absolute, datafile_path_absolute, attachment_path_absolute
     ):
         yield directory
 


### PR DESCRIPTION
Pytest 9.1 has deprecated the use of class-scoped fixtures defined as instance methods without `@classmethod`. Instead of just emitting a deprecation warning though, this seems to be causing the tests to fail.

The fix is to convert these fixtures to class methods.